### PR TITLE
Support CodeMirror 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "ts-loader": "^9.3.1",
     "typescript": "^4.8.2",
     "webpack": "^5.74.0",
-    "webpack-cli": "^4.10.0"
+    "webpack-cli": "^4.10.0",
+    "@codemirror/view": "6.24.1",
+    "@codemirror/state": "6.4.1"
   },
   "dependencies": {
     "@felisdiligens/md-table-tools": "^0.1.0",

--- a/plugin.config.json
+++ b/plugin.config.json
@@ -1,7 +1,6 @@
 {
 	"extraScripts": [
-		"cmPlugin.ts",
-		"cmUtils.ts",
+		"cmPlugin/index.ts",
 		"commands.ts",
 		"dialogs.ts",
 		"settings.ts",

--- a/src/cmPlugin/cmDynamicRequire.ts
+++ b/src/cmPlugin/cmDynamicRequire.ts
@@ -1,0 +1,16 @@
+/**
+ * Imports for `@codemirror/` packages can fail when Joplin's CodeMirror 5 editor is open.
+ * Because we want to support both CodeMirror 5 and CodeMirror 6, we require the CM6 packages
+ * dynamically, and only when CM6 is available.
+ */
+
+import type * as CodeMirrorStateType from '@codemirror/state';
+import type * as CodeMirrorViewType from '@codemirror/view';
+
+export function requireCodeMirrorState() {
+    return require('@codemirror/state') as typeof CodeMirrorStateType;
+}
+
+export function requireCodeMirrorView() {
+    return require('@codemirror/view') as typeof CodeMirrorViewType;
+}

--- a/src/cmPlugin/cmUtils.ts
+++ b/src/cmPlugin/cmUtils.ts
@@ -24,6 +24,10 @@ function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+export function isCodeMirror6(cm: Editor) {
+    return !!(cm as any).cm6;
+}
+
 function determineColumnIndex(line: string, ch: number): number {
     let row = line.substring(0, ch).trim();
     if (row.startsWith("|"))

--- a/src/cmPlugin/index.ts
+++ b/src/cmPlugin/index.ts
@@ -1,9 +1,11 @@
 import { Editor } from "codemirror";
+import { EditorView, keymap } from "@codemirror/view";
 import { Table, TextAlignment } from "@felisdiligens/md-table-tools";
-import { createPosition, getColumnRanges, getRangeOfTable, isCursorInTable, replaceAllTablesFunc, replaceRange, replaceRangeFunc, replaceSelectionFunc } from "./cmUtils";
-import { getCSVRenderer, getHTMLRenderer, getMarkdownParser, getMarkdownRenderer, parseTable } from "./tableUtils";
+import { createPosition, getColumnRanges, isCodeMirror6, isCursorInTable, replaceAllTablesFunc, replaceRange, replaceRangeFunc, replaceSelectionFunc } from "./cmUtils";
+import { getCSVRenderer, getHTMLRenderer, getMarkdownParser, getMarkdownRenderer, parseTable } from "../tableUtils";
+import makeKeyCommands from "./makeTableKeyCommands";
+import { Prec } from "@codemirror/state";
 
-const separatorRegex = /^\|?([\s\.]*:?[\-=\.]+[:\+]?[\s\.]*\|?)+\|?$/;
 
 module.exports = {
     default: function(context) {
@@ -299,156 +301,43 @@ module.exports = {
                 Hotkeys:
                 Tab, Shift+Tab, Enter
             */
-            CodeMirror.defineOption('tableToolsHotkeys', false, (cm: Editor, value: boolean) => {
-                cm.on('cursorActivity', async () => {
-                    const settings = await context.postMessage({ name: 'getSettings' });
-                    var insideTable = isCursorInTable(cm, settings.selectedFormat == "multimd");
+            CodeMirror.defineOption('tableToolsHotkeys', false, async (cm: Editor, value: boolean) => {
+                const settings = await context.postMessage({ name: 'getSettings' });
+                const keyCommands = makeKeyCommands(settings);
 
-                    // if the cursor is in the table and hotkeys are allowed:
-                    if (insideTable && settings.allowHotkeys) {
-                        const cursor = cm.getCursor();
+                if (isCodeMirror6(cm)) {
+                    const editorControl = cm as any;
 
-                        cm.setOption("extraKeys", {
-                            // Insert <br> instead of normal newline:
-                            "Enter": (cm) => {
-                                if (settings.enterBehavior == "disabled") {
-                                    cm.replaceSelection('\n');
-                                    return;
-                                }
+                    // Convert all key commands into CodeMirror6-style keybindings.
+                    const keybindings = Object.entries(keyCommands).map(([name, command]) => ({
+                        key: name,
+                        run: (_view: EditorView) => {
+                            const insideTable = isCursorInTable(cm, settings.selectedFormat == "multimd");
 
-                                var line = cm.getLine(cursor.line);
-                                var substr = line.substring(cursor.ch, line.length);
-
-                                // Check if the cursor is within the table:
-                                if (settings.enterBehavior == "insertBrTag" &&
-                                    (!line.trim().startsWith("|") || (substr.includes("|") && cursor.ch != 0))) {
-                                    cm.replaceSelection('<br>');
-                                } else {
-                                    cm.replaceSelection('\n');
-                                }
-                            },
-                            // Jump to next cell:
-                            "Tab": (cm) => {
-                                if (settings.tabBehavior == "disabled") {
-                                    cm.replaceSelection('\t');
-                                    return;
-                                }
-
-                                let colIndex = -1;
-                                if (settings.formatOnTab) {
-                                    try {
-                                        const selection = getRangeOfTable(cm, settings.selectedFormat == "multimd");
-                                        if (selection !== null) {
-                                            const parsedTable = getMarkdownParser(settings.selectedFormat).parse(cm.getRange(selection.range.from, selection.range.to));
-                                            const formattedTable = getMarkdownRenderer(settings.selectedFormat, true).render(parsedTable);
-                                            if (formattedTable)
-                                                cm.replaceRange(formattedTable, selection.range.from, selection.range.to);
-                                            colIndex = selection.column;
-                                        }
-                                    } catch (err) {
-                                        console.error(`Couldn't format table on TAB: ${err}`);
-                                    }
-                                }
-
-                                let col = getColumnRanges(cm.getLine(cursor.line), cursor, colIndex);
-                                let range;
-                                // Does next cell exist in row?
-                                if (col.nextRange) {
-                                    // then select that cell:
-                                    range = col.nextRange;
-                                } else {
-                                    // if not, first select to the current cell:
-                                    range = col.currentRange;
-                                    // skip separator row:
-                                    let i = cm.getLine(cursor.line + 1).match(separatorRegex) ? 2 : 1;
-                                    // then check, if next row exist and select the first cell in the next row:
-                                    if (cm.getLine(cursor.line + i).includes("|")) {
-                                        col = getColumnRanges(cm.getLine(cursor.line + i), createPosition(cursor.line + i, 0));
-                                        if (col.ranges.length > 0)
-                                            range = col.firstRange;
-                                    }
-                                }
-
-                                if (range) {
-                                    cm.focus();
-                                    switch (settings.tabBehavior) {
-                                        case "jumpToStart":
-                                            cm.setCursor(range.from);
-                                            break;
-                                        case "jumpToEnd":
-                                            cm.setCursor(range.to);
-                                            break;
-                                        case "selectContent":
-                                            cm.setSelection(range.from, range.to);
-                                            break;
-                                    }
-                                    cm.refresh(); // This is required for the cursor to actually be visible
-                                }
-                            },
-                            // Jump to previous cell:
-                            "Shift-Tab": (cm) => {
-                                if (settings.tabBehavior == "disabled") {
-                                    cm.replaceSelection('\t');
-                                    return;
-                                }
-
-                                let colIndex = -1;
-                                if (settings.formatOnTab) {
-                                    try {
-                                        const selection = getRangeOfTable(cm, settings.selectedFormat == "multimd");
-                                        if (selection !== null) {
-                                            const parsedTable = getMarkdownParser(settings.selectedFormat).parse(cm.getRange(selection.range.from, selection.range.to));
-                                            const formattedTable = getMarkdownRenderer(settings.selectedFormat, true).render(parsedTable);
-                                            if (formattedTable)
-                                                cm.replaceRange(formattedTable, selection.range.from, selection.range.to);
-                                            colIndex = selection.column;
-                                        }
-                                    } catch (err) {
-                                        console.error(`Couldn't format table on TAB: ${err}`);
-                                    }
-                                }
-
-                                let col = getColumnRanges(cm.getLine(cursor.line), cursor, colIndex);
-                                let range;
-                                // Does previous cell exist in row?
-                                if (col.previousRange) {
-                                    // then select that cell:
-                                    range = col.previousRange;
-                                } else {
-                                    // if not, first select to the current cell:
-                                    range = col.currentRange;
-                                    // skip separator row:
-                                    let i = cm.getLine(cursor.line - 1).match(separatorRegex) ? 2 : 1;
-                                    // then check, if previous row exist and select the last cell in the previous row:
-                                    if (cm.getLine(cursor.line - i).includes("|")) {
-                                        col = getColumnRanges(cm.getLine(cursor.line - i), createPosition(cursor.line - i, 0));
-                                        if (col.ranges.length > 0)
-                                            range = col.lastRange;
-                                    }
-                                }
-
-                                if (range) {
-                                    cm.focus();
-                                    switch (settings.tabBehavior) {
-                                        case "jumpToStart":
-                                            cm.setCursor(range.from);
-                                            break;
-                                        case "jumpToEnd":
-                                            cm.setCursor(range.to);
-                                            break;
-                                        case "selectContent":
-                                            cm.setSelection(range.from, range.to);
-                                            break;
-                                    }
-                                    cm.refresh(); // This is required for the cursor to actually be visible
-                                }
+                            if (insideTable && settings.allowHotkeys) {
+                                command(cm);
+                                return true;
                             }
-                        });
-                    } else {
-                        // Disable the extraKeys when the cursor is not in the table:
-                        cm.setOption("extraKeys", {});
-                    }
-                });
+                            return false;
+                        },
+                    }));
+                    editorControl.addExtension([
+                        // High precedence: Override the default keybindings
+                        Prec.high(keymap.of(keybindings))
+                    ]);
+                } else {
+                    cm.on('cursorActivity', async () => {
+                        var insideTable = isCursorInTable(cm, settings.selectedFormat == "multimd");
+
+                        // if the cursor is in the table and hotkeys are allowed:
+                        if (insideTable && settings.allowHotkeys) {
+                            cm.setOption("extraKeys", keyCommands);
+                        } else {
+                            // Disable the extraKeys when the cursor is not in the table:
+                            cm.setOption("extraKeys", {});
+                        }
+                    });
+                }
             });
         }
 

--- a/src/cmPlugin/index.ts
+++ b/src/cmPlugin/index.ts
@@ -1,10 +1,10 @@
 import { Editor } from "codemirror";
-import { EditorView, keymap } from "@codemirror/view";
+import type { EditorView } from "@codemirror/view";
 import { Table, TextAlignment } from "@felisdiligens/md-table-tools";
 import { createPosition, getColumnRanges, isCodeMirror6, isCursorInTable, replaceAllTablesFunc, replaceRange, replaceRangeFunc, replaceSelectionFunc } from "./cmUtils";
 import { getCSVRenderer, getHTMLRenderer, getMarkdownParser, getMarkdownRenderer, parseTable } from "../tableUtils";
 import makeKeyCommands from "./makeTableKeyCommands";
-import { Prec } from "@codemirror/state";
+import { requireCodeMirrorState, requireCodeMirrorView } from "./cmDynamicRequire";
 
 
 module.exports = {
@@ -307,6 +307,10 @@ module.exports = {
 
                 if (isCodeMirror6(cm)) {
                     const editorControl = cm as any;
+
+                    // Dynamic require: Non-dynamic requires of these may break in CodeMirror 5.
+                    const { Prec } = requireCodeMirrorState();
+                    const { keymap } = requireCodeMirrorView();
 
                     // Convert all key commands into CodeMirror6-style keybindings.
                     const keybindings = Object.entries(keyCommands).map(([name, command]) => ({

--- a/src/cmPlugin/makeTableKeyCommands.ts
+++ b/src/cmPlugin/makeTableKeyCommands.ts
@@ -1,0 +1,158 @@
+import { getRangeOfTable, getColumnRanges, createPosition } from "./cmUtils";
+import { getMarkdownParser, getMarkdownRenderer } from "../tableUtils";
+
+const separatorRegex = /^\|?([\s\.]*:?[\-=\.]+[:\+]?[\s\.]*\|?)+\|?$/;
+
+type KeyCommand = (cm: any)=>void;
+
+/**
+ * Creates keyboard commands for table editing and navigation.
+ * 
+ * @param settings Record containing the plugin's user-configurable settings.
+ * @returns Keyboard commands that can be used directly with CodeMirror 5 or, after modification,
+ *          with CodeMirror 6.
+ */
+const makeKeyCommands = (settings: Record<string, any>): Record<string, KeyCommand> => ({
+    // Insert <br> instead of normal newline:
+    "Enter": (cm) => {
+        if (settings.enterBehavior == "disabled") {
+            cm.replaceSelection('\n');
+            return;
+        }
+
+        const cursor = cm.getCursor();
+        var line = cm.getLine(cursor.line);
+        var substr = line.substring(cursor.ch, line.length);
+
+        // Check if the cursor is within the table:
+        if (settings.enterBehavior == "insertBrTag" &&
+            (!line.trim().startsWith("|") || (substr.includes("|") && cursor.ch != 0))) {
+            cm.replaceSelection('<br>');
+        } else {
+            cm.replaceSelection('\n');
+        }
+    },
+    // Jump to next cell:
+    "Tab": (cm) => {
+        if (settings.tabBehavior == "disabled") {
+            cm.replaceSelection('\t');
+            return;
+        }
+
+        // Get the cursor before formatting -- formatting the table can move the cursor.
+        const cursor = cm.getCursor();
+
+        let colIndex = -1;
+        if (settings.formatOnTab) {
+            try {
+                const selection = getRangeOfTable(cm, settings.selectedFormat == "multimd");
+                if (selection !== null) {
+                    const parsedTable = getMarkdownParser(settings.selectedFormat).parse(cm.getRange(selection.range.from, selection.range.to));
+                    const formattedTable = getMarkdownRenderer(settings.selectedFormat, true).render(parsedTable);
+                    if (formattedTable)
+                        cm.replaceRange(formattedTable, selection.range.from, selection.range.to);
+                    colIndex = selection.column;
+                }
+            } catch (err) {
+                console.error(`Couldn't format table on TAB: ${err}`);
+            }
+        }
+
+        let col = getColumnRanges(cm.getLine(cursor.line), cursor, colIndex);
+        let range;
+        // Does next cell exist in row?
+        if (col.nextRange) {
+            // then select that cell:
+            range = col.nextRange;
+        } else {
+            // if not, first select to the current cell:
+            range = col.currentRange;
+            // skip separator row:
+            let i = cm.getLine(cursor.line + 1).match(separatorRegex) ? 2 : 1;
+            // then check, if next row exist and select the first cell in the next row:
+            if (cm.getLine(cursor.line + i).includes("|")) {
+                col = getColumnRanges(cm.getLine(cursor.line + i), createPosition(cursor.line + i, 0));
+                if (col.ranges.length > 0)
+                    range = col.firstRange;
+            }
+        }
+
+        if (range) {
+            cm.focus();
+            switch (settings.tabBehavior) {
+                case "jumpToStart":
+                    cm.setCursor(range.from);
+                    break;
+                case "jumpToEnd":
+                    cm.setCursor(range.to);
+                    break;
+                case "selectContent":
+                    cm.setSelection(range.from, range.to);
+                    break;
+            }
+            cm.refresh(); // This is required for the cursor to actually be visible
+        }
+    },
+    // Jump to previous cell:
+    "Shift-Tab": (cm) => {
+        if (settings.tabBehavior == "disabled") {
+            cm.replaceSelection('\t');
+            return;
+        }
+
+        const cursor = cm.getCursor();
+
+        let colIndex = -1;
+        if (settings.formatOnTab) {
+            try {
+                const selection = getRangeOfTable(cm, settings.selectedFormat == "multimd");
+                if (selection !== null) {
+                    const parsedTable = getMarkdownParser(settings.selectedFormat).parse(cm.getRange(selection.range.from, selection.range.to));
+                    const formattedTable = getMarkdownRenderer(settings.selectedFormat, true).render(parsedTable);
+                    if (formattedTable)
+                        cm.replaceRange(formattedTable, selection.range.from, selection.range.to);
+                    colIndex = selection.column;
+                }
+            } catch (err) {
+                console.error(`Couldn't format table on TAB: ${err}`);
+            }
+        }
+
+        let col = getColumnRanges(cm.getLine(cursor.line), cursor, colIndex);
+        let range;
+        // Does previous cell exist in row?
+        if (col.previousRange) {
+            // then select that cell:
+            range = col.previousRange;
+        } else {
+            // if not, first select to the current cell:
+            range = col.currentRange;
+            // skip separator row:
+            let i = cm.getLine(cursor.line - 1).match(separatorRegex) ? 2 : 1;
+            // then check, if previous row exist and select the last cell in the previous row:
+            if (cm.getLine(cursor.line - i).includes("|")) {
+                col = getColumnRanges(cm.getLine(cursor.line - i), createPosition(cursor.line - i, 0));
+                if (col.ranges.length > 0)
+                    range = col.lastRange;
+            }
+        }
+
+        if (range) {
+            cm.focus();
+            switch (settings.tabBehavior) {
+                case "jumpToStart":
+                    cm.setCursor(range.from);
+                    break;
+                case "jumpToEnd":
+                    cm.setCursor(range.to);
+                    break;
+                case "selectContent":
+                    cm.setSelection(range.from, range.to);
+                    break;
+            }
+            cm.refresh(); // This is required for the cursor to actually be visible
+        }
+    }
+});
+
+export default makeKeyCommands;

--- a/src/cmUtils.ts
+++ b/src/cmUtils.ts
@@ -85,7 +85,10 @@ export function getColumnRanges(line: string, cursor: Position, overrideColIndex
  */
 export function getRangesOfAllTables(cm: Editor, allowEmptyLine: boolean): Range[] {
     let ranges: Range[] = [];
-    const doc = cm.getDoc();
+
+    // In some versions of Joplin's beta editor, .getDoc is undefined.
+    const doc = cm.getDoc?.() ?? cm;
+
     let cursor = { } as Position;
 
     let tableStartLine = -1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,6 @@ joplin.plugins.register({
             }
         });
         
-        await joplin.contentScripts.register(ContentScriptType.CodeMirrorPlugin, "MultiMarkdownTableTools", "./cmPlugin.js");
+        await joplin.contentScripts.register(ContentScriptType.CodeMirrorPlugin, "MultiMarkdownTableTools", "./cmPlugin/index.js");
     },
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,6 +85,7 @@ function currentGitInfo() {
 function validateCategories(categories) {
 	if (!categories) return null;
 	if ((categories.length !== new Set(categories).size)) throw new Error('Repeated categories are not allowed');
+	// eslint-disable-next-line github/array-foreach -- Old code before rule was applied
 	categories.forEach(category => {
 		if (!allPossibleCategories.map(category => { return category.name; }).includes(category)) throw new Error(`${category} is not a valid category. Please make sure that the category name is lowercase. Valid categories are: \n${allPossibleCategories.map(category => { return category.name; })}\n`);
 	});
@@ -92,18 +93,24 @@ function validateCategories(categories) {
 
 function validateScreenshots(screenshots) {
 	if (!screenshots) return null;
-	screenshots.forEach(screenshot => {
+	for (const screenshot of screenshots) {
 		if (!screenshot.src) throw new Error('You must specify a src for each screenshot');
+
+		// Avoid attempting to download and verify URL screenshots.
+		if (screenshot.src.startsWith('https://') || screenshot.src.startsWith('http://')) {
+			continue;
+		}
 
 		const screenshotType = screenshot.src.split('.').pop();
 		if (!allPossibleScreenshotsType.includes(screenshotType)) throw new Error(`${screenshotType} is not a valid screenshot type. Valid types are: \n${allPossibleScreenshotsType}\n`);
 
-		const screenshotPath = path.resolve(srcDir, screenshot.src);
+		const screenshotPath = path.resolve(rootDir, screenshot.src);
+
 		// Max file size is 1MB
 		const fileMaxSize = 1024;
 		const fileSize = fs.statSync(screenshotPath).size / 1024;
 		if (fileSize > fileMaxSize) throw new Error(`Max screenshot file size is ${fileMaxSize}KB. ${screenshotPath} is ${fileSize}KB`);
-	});
+	}
 }
 
 function readManifest(manifestPath) {
@@ -116,7 +123,7 @@ function readManifest(manifestPath) {
 }
 
 function createPluginArchive(sourceDir, destPath) {
-	const distFiles = glob.sync(`${sourceDir}/**/*`, { nodir: true })
+	const distFiles = glob.sync(`${sourceDir}/**/*`, { nodir: true, windowsPathsNoEscape: true })
 		.map(f => f.substr(sourceDir.length + 1));
 
 	if (!distFiles.length) throw new Error('Plugin archive was not created because the "dist" directory is empty');
@@ -130,7 +137,7 @@ function createPluginArchive(sourceDir, destPath) {
 			cwd: sourceDir,
 			sync: true,
 		},
-		distFiles
+		distFiles,
 	);
 
 	console.info(chalk.cyan(`Plugin archive has been created in ${destPath}`));
@@ -208,13 +215,44 @@ const pluginConfig = { ...baseConfig, entry: './src/index.ts',
 		}),
 	] };
 
-const extraScriptConfig = { ...baseConfig, resolve: {
-	alias: {
-		api: path.resolve(__dirname, 'api'),
+
+// These libraries can be included with require(...) or
+// joplin.require(...) from content scripts.
+const externalContentScriptLibraries = [
+	'@codemirror/view',
+	'@codemirror/state',
+	'@codemirror/language',
+	'@codemirror/autocomplete',
+	'@codemirror/commands',
+	'@codemirror/highlight',
+	'@codemirror/lint',
+	'@codemirror/lang-html',
+	'@codemirror/lang-markdown',
+	'@codemirror/language-data',
+	'@lezer/common',
+	'@lezer/markdown',
+	'@lezer/highlight',
+];
+
+const extraScriptExternals = {};
+for (const library of externalContentScriptLibraries) {
+	extraScriptExternals[library] = { commonjs: library };
+}
+
+const extraScriptConfig = {
+	...baseConfig,
+	resolve: {
+		alias: {
+			api: path.resolve(__dirname, 'api'),
+		},
+		fallback: moduleFallback,
+		extensions: ['.js', '.tsx', '.ts', '.json'],
 	},
-	fallback: moduleFallback,
-	extensions: ['.js', '.tsx', '.ts', '.json'],
-} };
+
+	// We support requiring @codemirror/... libraries through require('@codemirror/...')
+	externalsType: 'commonjs',
+	externals: extraScriptExternals,
+};
 
 const createArchiveConfig = {
 	stats: 'errors-only',


### PR DESCRIPTION
# Summary

Adds support for Joplin's beta CodeMirror 6-based markdown editor (see [the Joplin plugin tutorial](https://joplinapp.org/help/api/tutorials/cm6_plugin)).

To do this, it,
1. Works around an issue in the CodeMirror compatibility layer (`.getDoc` is undefined)
2. [Updates the plugin build script](https://joplinapp.org/help/api/tutorials/cm6_plugin#update-the-plugin-build-script) to allow importing `@codemirror/` packages at runtime.
3. Registers keyboard commands [with a CodeMirror 6 extension](https://codemirror.net/docs/ref/#view.keymap) when in CodeMirror 6.

# Notes

- Does not commit changes to `package-lock.json`.
- CodeMirror 6 plugin support requires Joplin >=  2.14.6.

# Testing

1. Enable the beta editor
2. Create a new 3x3 table with header using the toolbar button
3. Fill each of the cells (navigate using <kbd>tab</kbd>)
4. Navigate back to the beginning of the table with <kbd>shift</kbd>-<kbd>tab</kbd>
5. Minify the table using the menu item
6. Undo the minification
7. Click on the second-to-last row
8. Add a new line using <kbd>ctrl</kbd>-<kbd>enter</kbd>
9. Add a new column using the toolbar button.
10. Align the column to the left
11. Align the column to the right
12. Repeat for the legacy CodeMirror 5 editor.

This has been tested successfully in Joplin 2.14.16 on Ubuntu 23.10.

https://github.com/FelisDiligens/joplin-plugin-multimd-table-tools/assets/46334387/78815145-8765-4d9d-a6e8-eb96cdd65872

